### PR TITLE
Update project URL and add security policy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ description = "A dashboard for visualizing progress of asynchronous and possibly
 edition = "2021"
 include = ["src/**/*", "README.md", "LICENSE.md", "CHANGELOG.md"]
 license = "MIT"
-repository = "https://github.com/Byron/prodash"
+repository = "https://github.com/GitoxideLabs/prodash"
 readme = "README.md"
 rust-version = "1.74"
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Rust](https://github.com/Byron/prodash/workflows/Rust/badge.svg)
+![Rust](https://github.com/GitoxideLabs/prodash/workflows/Rust/badge.svg)
 [![Crates.io](https://img.shields.io/crates/v/prodash.svg)](https://crates.io/crates/prodash)
 
 **prodash** allows to integrate progress reporting into concurrent applications and provides renderers for displaying it in various ways.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,9 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Please feel free to [draft a GitHub advisory](https://github.com/GitoxideLabs/prodash/security/advisories/new), and I will work with you to disclose and or resolve the issue responsibly.
+
+If this doesn't seem like the right approach or there are questions, please feel free to reach out to the email used in Sebastian Thiel's commits.
+
+Thank you.


### PR DESCRIPTION
This makes two changes, similar to https://github.com/GitoxideLabs/cargo-smart-release/pull/55:

- Update the project URL in `Cargo.toml`, as well as a badge URL in the readme, to point to `GitoxideLabs/prodash`, since the repo was moved (though the old URL will still work as a redirect).
- Add a `SECURITY.md` file with the same wording as in `gitoxide` and `cargo-smart-release`, with a hyperlink to draft a `prodash` advisory.

I'm going ahead with this based on https://github.com/GitoxideLabs/cargo-smart-release/pull/55#issuecomment-2817035436.

The Rust badge in the readme is broken, but it was also broken before. I think that can be handled separately.