### PR TITLE
feature `progress-tree-log` should not be default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ required-features = [
 ]
 
 [features]
-default = ["progress-tree", "progress-tree-log"]
+default = ["progress-tree"]
 progress-tree = ["parking_lot"]
 progress-tree-hp-hashmap = ["dashmap"]
 progress-tree-log = ["log"]


### PR DESCRIPTION
I propose `progress-tree-log` should **not** be a default feature, here are my reasons:

1. When using `prodash` and `gix` in the same cargo project, it is impossible to remove progress-tree-log without cargo patching either of them.
2. Some projects do **not** use a logging library that supports log interface (log, tracing, etc) and this adds unnecessary compile time.
3. If you do have a logging library and you try to render a line progress bar, the `INFO` logs fill up the terminal space where the progress bar is rendering. It also floods the progress bars existing messages that are already printed, effectively duplicating them.

Most should believe this is **not** default behavior for many project. I am not sure how to announce this change as it *may* be breaking for some users (breaking is a stretch, it just wont log. looking at the docs it is pretty easy to find that you would have to enable this feature)

Please consider this change as it would greatly help many users.

Thanks!