### PR TITLE
Really don't describe `progress-tree-log` as a default feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This crate comes with various cargo features to tailor it to your needs.
   * **progress-tree-hp-hashmap** - high-performance registry for pregree tree nodes in case of ultra-heavy insertions and deletions.
     * If this is necessary, it's probably impossible to resonably visualize the progress tree anyway, but the option exists nonetheless in case
       it is ever needed. Historically, this was the default, but now it seems simpler is better and just fine for typical programs.
-  * **progress-tree-log** _(default)_
+  * **progress-tree-log**
     * If logging in the `log` crate is initialized, a `log` will be used to output all messages provided to
       `tree::Item::message(…)` and friends. No actual progress is written.
     * May interfere with `render-tui` or `render-line`, or any renderer outputting to the console.


### PR DESCRIPTION
Fixes #40

cf70e4a (#41) fixed this in the documentation comments in `lib.rs`, but it had still been listed as a default in the readme, noted in .https://github.com/GitoxideLabs/prodash/pull/39#issuecomment-2966759888