### PR TITLE
Remove errant CI step fragment `progress-tree"`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,4 +55,4 @@ jobs:
       uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # v1.0.3
       with:
         command: test
-        args: --features=render-tui,render-tui-crossterm,render-line,render-line-crossterm,signal-hook,render-line-autoconfigure,progress-tree --all
+        args: --features=render-tui,render-tui-crossterm,render-line,render-line-crossterm,signal-hook,render-line-autoconfigure,progress-tree --all -- --skip render::tui


### PR DESCRIPTION
This fragment, with an unmatched quote, in the "Test (crossterm)" step on in the Windows test job, has been present ever since an attempt to expand what is tested on Windows in b7e0f2c (#13). It looks like [no tests ever run](https://github.com/GitoxideLabs/prodash/actions/runs/20904700969/job/60056157118) as part of this step; it may be that the action parses this into something that filters out all tests. This change removes the fragment in the hope to enable some tests.

Having enabled tests on Windows, this also explicitly skips `render::tui` on Windows, since it blocks forever (it never completes), at least as run on CI.