### PR TITLE
Verify the declared MSRV in CI, and record the all-features floor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,9 +49,9 @@ jobs:
     runs-on: ubuntu-latest
     env:
       # Not the MSRV. `rust-version` covers the base crate, while optional features can
-      # need newer compilers through their optional dependencies. This value is one
-      # release too low on purpose, to show the job failing when the floor is wrong.
-      ALL_FEATURES_FLOOR: "1.87.0"
+      # need newer compilers through their optional dependencies. Hard-coded, so that
+      # a rise in this floor fails here.
+      ALL_FEATURES_FLOOR: "1.88.0"
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,22 @@ jobs:
     - name: Check the base crate on the declared MSRV
       run: cargo "+$MSRV" check --locked --lib
 
+  all-features-floor:
+    runs-on: ubuntu-latest
+    env:
+      # Not the MSRV. `rust-version` covers the base crate, while optional features can
+      # need newer compilers through their optional dependencies. This value is one
+      # release too low on purpose, to show the job failing when the floor is wrong.
+      ALL_FEATURES_FLOOR: "1.87.0"
+    steps:
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
+    - name: Install the all-features floor toolchain
+      run: rustup toolchain install "$ALL_FEATURES_FLOOR" --profile minimal --no-self-update
+    - name: Check every feature at once
+      run: cargo "+$ALL_FEATURES_FLOOR" check --locked --all-features
+
   build-and-test-linux:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,36 @@ permissions:
   contents: read
 
 jobs:
+  msrv:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
+    - name: Find the declared MSRV
+      shell: bash  # Without this, the shell here is `bash` but without `-o pipefail`.
+      run: |
+        msrv="$(
+          cargo metadata --format-version 1 --no-deps |
+            jq -er '
+              .packages[]
+              | select(.name == "prodash")
+              | .rust_version
+            '
+        )"
+
+        # Expand to x.y.0, since rustup would otherwise install the newest x.y.z.
+        case "$msrv" in
+          *.*.*) ;;
+          *) msrv="$msrv.0" ;;
+        esac
+
+        tee -a "$GITHUB_ENV" <<<"MSRV=$msrv"
+    - name: Install the MSRV toolchain
+      run: rustup toolchain install "$MSRV" --profile minimal --no-self-update
+    - name: Check the base crate on the declared MSRV
+      run: cargo "+$MSRV" check --locked --lib
+
   build-and-test-linux:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
*Written by Claude Opus 5 in Claude Code, on behalf of Eliah Kagan.*

CI builds only on `stable`, so `rust-version` has never been exercised by a job. It is correct as it stands — `cargo +1.85.0 check --locked --lib` passes — but nothing would notice if that stopped being true.

This PR adds an `msrv` job that checks exactly what the declaration covers: the base crate. That scope is deliberate — [the commit that set 1.85](https://github.com/GitoxideLabs/prodash/commit/84f279d4b5f72d77f188d879357cdd952ccd0d30) records that the declared MSRV "covers the base crate, while optional feature combinations may require newer compilers through their optional dependencies". Raising `rust-version` to cover them would impose a higher floor on the default feature set, which builds fine on 1.85. So the job runs `--lib` with default features, reading the toolchain from `cargo metadata` so the version tested cannot drift from the manifest.

Enabling all features needs 1.88.0, above the declared MSRV. This PR also adds a second job, `all-features-floor`, that records and validates that figure.
